### PR TITLE
Assistant URL in assistant.ini i obsolete

### DIFF
--- a/config/assistant.ini
+++ b/config/assistant.ini
@@ -3,7 +3,7 @@
 SESSION_TIMEOUT_IN_SECONDS=600
 
 [WATSON_ASSISTANT]
-WA_ENDPOINT = https://gateway.watsonplatform.net/assistant/api
+WA_ENDPOINT = https://api.us-south.assistant.watson.cloud.ibm.com
 WA_VERSION = 2019-02-28
 WA_OPT_OUT = FALSE
 


### PR DESCRIPTION
The current WA_ENDPOINT is obsolete and needs to be updated. https://gateway.watsonplatform.net is obsolete.

Ideally it would be a documented parameter so that this can work with Assistant in any region.  I just hardcoded the us-south endpoint, but this change is untested. The URL should be a parameter so that it can be copied from the service and will work in any region.

I would have opened an issue instead of a PR, but this repo is not accepting issues.  So, I'm thinking this is unmaintained and should be archived.